### PR TITLE
Fix link to docker image

### DIFF
--- a/docs/cli/introduction.mdx
+++ b/docs/cli/introduction.mdx
@@ -21,7 +21,7 @@ You can download the latest binaries from the [release page](https://github.com/
 curl -sL https://filen.io/cli.sh | bash
 ```
 
-Docker images are also available as [filen/cli](https://hub.docker.com/repository/docker/filen/cli) (see [below](#using-docker)).
+Docker images are also available as [filen/cli](https://hub.docker.com/r/filen/cli) (see [below](#using-docker)).
 
 The Filen CLI includes an automatic updater that checks for a new release every time the CLI is invoked
 (after checking for updates, it will not check again for the next 10 minutes).


### PR DESCRIPTION
Hi
I've discovered that the link to docker image in docs redirects to `https://hub.docker.com/repository/docker/filen/cli`  which is repository management site (to access this site user needs to have right permissions achieved from repository owners).

The more convenient way is to use the link to docker hub (https://hub.docker.com/r/filen/cli) which doesn't require docker account, permission and it's basically a typical approach in docker word :) 

This PR changes the link in docs to proper docker hub link. 